### PR TITLE
Fix animated salary overflowing container on mobile

### DIFF
--- a/src/components/Filters.jsx
+++ b/src/components/Filters.jsx
@@ -106,7 +106,7 @@ export function Filters () {
   return (
     <section id='salaries-filter'>
       <SalariesSectionTitle icon={<IconFilter />} title='Filtrar salario' />
-      <Card className='flex items-center justify-between'>
+      <Card className='flex items-center justify-between flex-wrap'>
         <div className='flex flex-col flex-wrap items-start justify-start gap-2'>
           <div>
             <Dropdown


### PR DESCRIPTION
The layout might need more tweaks on mobile, but this fixes the immediate issue of unintended viewport widening.

BEFORE
![image](https://user-images.githubusercontent.com/6631050/230467510-bb511a8f-604a-453b-9c56-379a952d7232.png)


AFTER
![image](https://user-images.githubusercontent.com/6631050/230467416-8be4c757-50e4-4eaf-bfdb-815142e7453c.png)

