### PR TITLE
fix: typo in faqs section

### DIFF
--- a/src/components/Faqs.jsx
+++ b/src/components/Faqs.jsx
@@ -15,7 +15,7 @@ const faqs = [
       answer: 'Sí. Siempre y cuando nos cites como fuente.'
     },
     {
-      question: '¿Cuándo se activarán los paises de Latinoamérica?',
+      question: '¿Cuándo se activarán los países de Latinoamérica?',
       answer:
         'Estamos filtrando y arreglando los datos para que sean lo más precisos posibles. En breve estará disponible.'
     }


### PR DESCRIPTION
Fix a typographic error in the FAQs section, changing "paises" to "países".