### PR TITLE
Fix study filter by "studies"

### DIFF
--- a/src/pages/api/filtered-salary.js
+++ b/src/pages/api/filtered-salary.js
@@ -53,7 +53,7 @@ export default async function handler (req, res) {
     const $gender = GENDER[record.gender]
     const $experience = EXPERIENCE[record.experience]
     const $remote = REMOTE_MODALITIES[record.remote]
-    const $study = STUDIES[record.study]
+    const $study = STUDIES[record.studies]
 
     // check if record matches filters
     if (


### PR DESCRIPTION
The api was filtering by column "study", that doesn't exist in CSV data file. Replaced by the correct name "studies".

Now is filtering correctly.
![Captura de Pantalla 2023-04-07 a las 16 17 09](https://user-images.githubusercontent.com/8578099/230624086-05042cab-8681-4875-8565-94c77add2919.png)