### PR TITLE
Add button to copy attribution

### DIFF
--- a/src/components/APISection.jsx
+++ b/src/components/APISection.jsx
@@ -9,6 +9,7 @@ import { gradientDark as theme } from 'react-syntax-highlighter/dist/cjs/styles/
 import { Container } from '@/components/Container'
 import backgroundImage from '@/images/background-features.jpg'
 import { API_FEATURES_LIST } from '@/constants'
+import { CopyAttributionButton } from './CopyAttributionButton'
 
 export function APISection () {
   const [tabOrientation, setTabOrientation] = useState('horizontal')
@@ -50,6 +51,7 @@ export function APISection () {
           <p className='mt-6 text-lg tracking-tight text-blue-100'>
             Usa los datos de sueldos.dev sin límite.<br />Debes <span className='border-b '>añadir un enlace a sueldos.dev en tu sitio web al usar la API.</span>
           </p>
+          <CopyAttributionButton />
         </div>
         <Tab.Group
           as='div'

--- a/src/components/CopyAttributionButton.jsx
+++ b/src/components/CopyAttributionButton.jsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import { IconCopy, IconCheck } from '@tabler/icons-react'
+import { Button } from '@/components/Button'
+
+const ATTRIBUTION_TEXT = 'Datos extraídos de <a href="https://sueldos.dev/">sueldos.dev</a>'
+
+export function CopyAttributionButton () {
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!copied) return
+
+    const timeoutId = setTimeout(() => setCopied(false), 2500)
+
+    return () => clearTimeout(timeoutId)
+  }, [copied])
+
+  const handleCopyAttribution = () => {
+    navigator.clipboard.writeText(ATTRIBUTION_TEXT).then(() => setCopied(true))
+  }
+
+  return (
+    <Button onClick={handleCopyAttribution} className='flex gap-2 items-center justify-center my-6 md:mx-auto self-center text-sm'>
+      <span>
+        Datos extraídos de <span className='underline'>sueldos.dev</span>
+      </span>
+      {copied ? <IconCheck /> : <IconCopy />}
+    </Button>
+  )
+}


### PR DESCRIPTION
Add a button to copy an attribution text for API consumers.

![sueldosdotdev-attribution-button](https://user-images.githubusercontent.com/98661193/230721001-3b95a935-e5e8-4591-8ceb-18c45c784db0.png)
