### PR TITLE
fix: enforce code xample to match page max width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# IDEs and editors
+.idea
+.vscode

--- a/src/components/APISection.jsx
+++ b/src/components/APISection.jsx
@@ -99,21 +99,19 @@ export function APISection () {
                   ))}
                 </Tab.List>
               </div>
-              <Tab.Panels className='lg:col-span-7'>
+              <Tab.Panels className='lg:col-span-7 relative'>
                 {API_FEATURES_LIST.map((feature) => (
                   <Tab.Panel key={feature.title} unmount={false}>
-                    <div className='relative sm:px-6 lg:hidden'>
-                      <div className='absolute -inset-x-4 bottom-[-4.25rem] top-[-6.5rem] bg-white/10 ring-1 ring-inset ring-white/10 sm:inset-x-0 sm:rounded-t-xl' />
+                    <div className='relative sm:px-6 lg:hidden z-0'>
+                      <div className='absolute -inset-x-4 bottom-[-4.25rem] top-[-6.5rem] bg-white/10 ring-1 ring-inset ring-white/10 sm:inset-x-0 sm:rounded-t-xl pointer-events-none' />
                       <p className='relative max-w-2xl mx-auto text-base text-white sm:text-center'>
                         {feature.description}
                       </p>
                     </div>
-                    <div className='mt-10 w-[45rem] overflow-hidden rounded-xl bg-slate-50 shadow-xl shadow-blue-900/20 sm:w-auto lg:mt-0 lg:w-[67.8125rem]'>
-                      <div className='editor w-full overflow-scroll h-96 [&>pre]:p-4!'>
-                        <SyntaxHighlighter
-                          language='javascript'
-                          style={theme}
-                        >{feature.code}
+                    <div className='mt-10 overflow-hidden rounded-xl bg-slate-50 shadow-xl shadow-blue-900/20 w-full lg:mt-0 z-10 relative'>
+                      <div className='editor w-full overflow-auto h-96 [&>pre]:p-4!'>
+                        <SyntaxHighlighter language='javascript' style={theme}>
+                          {feature.code}
                         </SyntaxHighlighter>
                       </div>
                     </div>


### PR DESCRIPTION
Making code xample in apiSection match page max width like the rest of the sections. Also in mobile there was some glitch that made tabs overlap the code xample in small screens.