### PR TITLE
FIX: Converts disabled links to buttons

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -17,11 +17,11 @@ export function Button ({
     disabled && 'opacity-50 cursor-not-allowed'
   )
 
-  return href
+  return href && !disabled
     ? (
       <Link href={href} className={className} {...props} />
       )
     : (
-      <button className={className} {...props} />
+      <button className={className} disabled {...props} />
       )
 }


### PR DESCRIPTION
When a link is disabled, it still works, we are simply styling it but not preventing navigation.

The simplest solution is add a condition that says that if it is a disabled link it returns a button (taking advantage of the component that already exists).

## How to replicate

Clicking on the apparently disabled "Añade tu salario" button in the header, currently it leads to a 404.

## Expected

It should do nothing on click.